### PR TITLE
Don't wait for the wake sound to finish before starting to stream the mic to reduce the delay needed after the wake word

### DIFF
--- a/app/src/main/java/com/example/ava/esphome/voicesatellite/VoicePipeline.kt
+++ b/app/src/main/java/com/example/ava/esphome/voicesatellite/VoicePipeline.kt
@@ -37,8 +37,6 @@ class VoicePipeline(
      * Calls the stateChanged and listeningChanged callbacks with the initial state.
      */
     suspend fun start(wakeWordPhrase: String = "") {
-        stateChanged(state)
-        listeningChanged(state == Listening)
         sendMessage(voiceAssistantRequest {
             start = true
             this.wakeWordPhrase = wakeWordPhrase

--- a/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatellite.kt
+++ b/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatellite.kt
@@ -218,14 +218,18 @@ class VoiceSatellite(
         Log.d(TAG, "Wake satellite")
         player.duck()
         pipeline = createPipeline()
+        // Start mic audio streaming as early as possible to minimise
+        // the need for a delay after saying the wake word.
+        audioInput.isStreaming = true
+        _state.value = Listening
         if (!isContinueConversation) {
-            // Start streaming audio only after the wake sound has finished
             player.playWakeSound {
                 scope.launch { pipeline?.start(wakeWordPhrase) }
             }
         } else {
             pipeline?.start()
         }
+
     }
 
     private fun createPipeline() = VoicePipeline(

--- a/app/src/test/java/com/example/ava/VoicePipelineTest.kt
+++ b/app/src/test/java/com/example/ava/VoicePipelineTest.kt
@@ -27,26 +27,6 @@ open class StubAudioPlayer : AudioPlayer {
 
 class VoicePipelineTest {
     @Test
-    fun should_fire_changed_callbacks_on_start() {
-        var listeningChangedCalled = false
-        var stateChangedCalled = false
-        val pipeline = VoicePipeline(
-            player = StubAudioPlayer(),
-            sendMessage = {},
-            listeningChanged = { listeningChangedCalled = true },
-            stateChanged = { stateChangedCalled = true },
-            ended = {}
-        )
-
-        runBlocking {
-            pipeline.start()
-        }
-
-        assert(listeningChangedCalled)
-        assert(stateChangedCalled)
-    }
-
-    @Test
     fun should_send_start_request() {
         val sentMessages = mutableListOf<MessageLite>()
         val pipeline = VoicePipeline(


### PR DESCRIPTION
- Set the mic streaming and satellite state immediately after waking
- Don't trigger state changes on pipeline start

Attempts to address #20