### PR TITLE
Ensure that the voice satellite is properly reset when ending the pipeline

### DIFF
--- a/app/src/main/java/com/example/ava/esphome/voicesatellite/VoicePipeline.kt
+++ b/app/src/main/java/com/example/ava/esphome/voicesatellite/VoicePipeline.kt
@@ -2,6 +2,7 @@ package com.example.ava.esphome.voicesatellite
 
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
+import com.example.ava.esphome.Connected
 import com.example.ava.esphome.EspHomeState
 import com.example.ava.players.AudioPlayer
 import com.example.esphomeproto.api.VoiceAssistantEvent
@@ -110,6 +111,9 @@ class VoicePipeline(
     }
 
     private fun fireEnded() {
+        // Sets the pipeline to 'idle', ensures that any
+        // state/listening changed callbacks are fired
+        updateState(Connected)
         ended(continueConversation)
     }
 

--- a/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatellite.kt
+++ b/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatellite.kt
@@ -261,7 +261,7 @@ class VoiceSatellite(
 
     private suspend fun onTtsFinished(continueConversation: Boolean) {
         Timber.d("TTS finished")
-        sendMessage(voiceAssistantAnnounceFinished { })
+        stopSatellite()
         if (continueConversation) {
             Timber.d("Continuing conversation")
             wakeSatellite(isContinueConversation = true)


### PR DESCRIPTION
The pipeline makes some assumptions about the order of requests from Home Assistant which aren't met when the wake words are tested in the Home Assistant setup wizard leaving it in an invalid state. Ensure that the pipeline is properly reset to a known state when the pipeline is ended.

Closes #42