### PR TITLE
Support self-signed certificates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Ava"
-        android:usesCleartextTraffic="true">
+        android:networkSecurityConfig="@xml/network_security_config">
         <service
             android:name=".services.VoiceSatelliteService"
             android:enabled="true"

--- a/app/src/main/java/com/example/ava/services/VoiceSatelliteService.kt
+++ b/app/src/main/java/com/example/ava/services/VoiceSatelliteService.kt
@@ -16,6 +16,7 @@ import com.example.ava.nsd.registerVoiceSatelliteNsd
 import com.example.ava.settings.VoiceSatelliteSettings
 import com.example.ava.settings.VoiceSatelliteSettingsStore
 import com.example.ava.tasker.observeTaskerState
+import com.example.ava.utils.setTrustAllSSLCertificates
 import com.example.ava.utils.translate
 import com.example.ava.wakelocks.WifiWakeLock
 import dagger.hilt.android.AndroidEntryPoint
@@ -75,6 +76,7 @@ class VoiceSatelliteService() : LifecycleService() {
         wifiWakeLock.create(applicationContext, TAG)
         createVoiceSatelliteServiceNotificationChannel(this)
         updateNotificationOnStateChanges()
+        startNetworkSettingsObserver()
         startTaskerStateObserver()
     }
 
@@ -109,6 +111,10 @@ class VoiceSatelliteService() : LifecycleService() {
         }
         return super.onStartCommand(intent, flags, startId)
     }
+
+    fun startNetworkSettingsObserver() = satelliteSettingsStore.trustAllSSLCerts.onEach {
+        setTrustAllSSLCertificates(it)
+    }.launchIn(lifecycleScope)
 
     private fun startTaskerStateObserver() = lifecycleScope.launch {
         _voiceSatellite.collectLatest { it?.observeTaskerState(this@VoiceSatelliteService) }

--- a/app/src/main/java/com/example/ava/settings/VoiceSatelliteSettings.kt
+++ b/app/src/main/java/com/example/ava/settings/VoiceSatelliteSettings.kt
@@ -27,7 +27,8 @@ data class VoiceSatelliteSettings(
     val name: String = "Android Voice Assistant",
     val serverPort: Int = DEFAULT_SERVER_PORT,
     val macAddress: String = DEFAULT_MAC_ADDRESS,
-    val autoStart: Boolean = false
+    val autoStart: Boolean = false,
+    val trustAllSSLCerts: Boolean = false,
 )
 
 private val DEFAULT = VoiceSatelliteSettings()
@@ -68,6 +69,14 @@ interface VoiceSatelliteSettingsStore : SettingsStore<VoiceSatelliteSettings> {
      */
     val autoStart: SettingState<Boolean>
         get() = setting(get = { autoStart }, set = { copy(autoStart = it) })
+
+    /**
+     * Whether to trust all SSL certificates.
+     */
+    val trustAllSSLCerts: SettingState<Boolean>
+        get() = setting(
+            get = { this.trustAllSSLCerts },
+            set = { copy(trustAllSSLCerts = it) })
 
     /**
      * Ensures that a mac address has been generated and persisted.

--- a/app/src/main/java/com/example/ava/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/ava/ui/screens/settings/SettingsScreen.kt
@@ -214,5 +214,17 @@ fun SettingsScreen(
                 onClearRequest = { viewModel.resetErrorSound() }
             )
         }
+        item {
+            HorizontalDivider()
+        }
+        item {
+            SwitchSetting(
+                name = stringResource(R.string.label_trust_all_ssl_certs),
+                description = stringResource(R.string.description_trust_all_ssl_certs),
+                value = satelliteState?.trustAllSSLCerts ?: false,
+                enabled = enabled,
+                onCheckedChange = { viewModel.saveTrustAllSSLCerts(it) }
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/ava/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/ava/ui/screens/settings/SettingsViewModel.kt
@@ -76,6 +76,10 @@ class SettingsViewModel @Inject constructor(
         satelliteSettingsStore.autoStart.set(autoStart)
     }
 
+    fun saveTrustAllSSLCerts(trustAllSSlCerts: Boolean) = viewModelScope.launch {
+        satelliteSettingsStore.trustAllSSLCerts.set(trustAllSSlCerts)
+    }
+
     fun saveWakeWord(wakeWordId: String, availableWakeWords: List<WakeWordWithId>) =
         viewModelScope.launch {
             if (availableWakeWords.any { it.id == wakeWordId }) {

--- a/app/src/main/java/com/example/ava/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ava/utils/NetworkUtils.kt
@@ -1,5 +1,13 @@
 package com.example.ava.utils
 
+import android.annotation.SuppressLint
+import timber.log.Timber
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 import kotlin.random.Random
 
 @OptIn(ExperimentalStdlibApi::class)
@@ -10,4 +18,38 @@ fun getRandomMacAddressString(): String {
         upperCase = true
         bytes { byteSeparator = ":" }
     })
+}
+
+/**
+ * A TrustManager that trusts all certificates.
+ */
+@SuppressLint("CustomX509TrustManager")
+private object TrustAllTrustManager : X509TrustManager {
+    @SuppressLint("TrustAllX509TrustManager")
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+    }
+
+    @SuppressLint("TrustAllX509TrustManager")
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+    }
+
+    override fun getAcceptedIssuers(): Array<out X509Certificate?> = arrayOf()
+}
+
+/**
+ * Sets whether SSL connections should trust all certificates, or use the default trust manager.
+ * Can be used as an unsafe workaround when using self-signed certificates.
+ */
+fun setTrustAllSSLCertificates(trustAll: Boolean) {
+    // If disabling, use a custom TrustManager that trusts all certificates,
+    // else set to null to use the default trust manager to [re]enable verification.
+    val trustManager = if (trustAll) arrayOf<TrustManager>(TrustAllTrustManager) else null
+
+    runCatching {
+        val sslContext = SSLContext.getInstance("SSL")
+        sslContext.init(null, trustManager, SecureRandom())
+        HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory)
+    }.onFailure { t ->
+        Timber.e(t, "Failed to ${if (trustAll) "disable" else "enable"} SSL verification")
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="description_voice_satellite_enable_error_sound">Play a sound when a voice assistant error occurs</string>
     <string name="label_custom_error_sound">Custom error sound</string>
     <string name="description_custom_error_sound_location">Specify a different file to play when a voice assistant error occurs</string>
+    <string name="label_trust_all_ssl_certs">Trust all SSL certificates</string>
+    <string name="description_trust_all_ssl_certs">Allow connections using untrusted self-signed certificates</string>
 
     <string name="label_audio_processing">Audio processing</string>
     <string name="description_audio_processing">Configure advanced microphone audio processing settings</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <!-- We need to allow clear traffic for those who don't have SSL setup. -->
+    <base-config cleartextTrafficPermitted="true"
+        tools:ignore="InsecureBaseConfiguration">
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system"/>
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user"
+                tools:ignore="AcceptsUserCertificates" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Trust user installed certificates by default and add a setting to additionally trust all certificates

- Add a network_security_config that trusts user installed certificates, the default on Android is to only trust system installed.
- Add a function to set the trust manager used for SSL connections to additionally trust all certificates as an unsafe workaround

Closes #79