### PR TITLE
Increase connect and read timeouts when playing media from a uri

### DIFF
--- a/app/src/main/java/com/example/ava/esphome/android/mediaplayer/Media3MediaPlayer.kt
+++ b/app/src/main/java/com/example/ava/esphome/android/mediaplayer/Media3MediaPlayer.kt
@@ -9,12 +9,19 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.example.ava.esphome.mediaplayer.MediaPlayer
 import com.example.esphomeproto.api.MediaPlayerState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import timber.log.Timber
+
+/**
+ * Timeout for HTTP requests in milliseconds.
+ */
+private const val HTTP_REQUEST_TIMEOUT_MS = 30000
 
 @OptIn(UnstableApi::class)
 fun Context.media3MediaPlayer(usage: Int, contentType: Int, focusGain: Int): MediaPlayer {
@@ -27,7 +34,21 @@ fun Context.media3MediaPlayer(usage: Int, contentType: Int, focusGain: Int): Med
                     .setContentType(contentType)
                     .build(),
                 false
-            ).build()
+            )
+            // TTS responses from Home Assistant are streamed as the text is generated,
+            // which can be slow and intermittent when using an LLM on low-end hardware.
+            // The player's default timeout for new data is 8 seconds, this can sometimes
+            // be exceeded if the response is particularly slow, causing the player to
+            // reconnect and restart playback from the beginning.
+            // Increase the timeouts to try and reduce the likelihood of this happening.
+            .setMediaSourceFactory(
+                ProgressiveMediaSource.Factory(
+                    DefaultHttpDataSource.Factory()
+                        .setConnectTimeoutMs(HTTP_REQUEST_TIMEOUT_MS)
+                        .setReadTimeoutMs(HTTP_REQUEST_TIMEOUT_MS)
+                )
+            )
+            .build()
     }
 }
 


### PR DESCRIPTION
Helps mitigate the timeout issues in #86 when playing tts streams that are slow to generate.

Closes #86